### PR TITLE
Enable continue button for empty dao proposals

### DIFF
--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
@@ -24,7 +24,9 @@ const SetupActions: React.FC = () => {
   return (
     <FlexBox width={'100%'} $direction='column' $gap={15} $justifyContent='center'>
       <Typography variant='secondary' size='2xl'>
-        The following {validActions.length} actions get executed when the proposal passes.
+        {validActions.length === 0
+          ? 'No actions will be executed when the proposal passes.'
+          : `The following ${validActions.length} action${validActions.length === 1 ? '' : 's'} get executed when the proposal passes.`}
       </Typography>
 
       <SetupActionsForm actions={actions} setActions={(actions) => updateProposal({ ...proposal, actions })} />
@@ -33,7 +35,7 @@ const SetupActions: React.FC = () => {
         <Button variant='secondary' onClick={handleBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={validActions.length === 0}>
+        <Button onClick={handleContinue}>
           Continue
         </Button>
       </FlexBox>


### PR DESCRIPTION
## Scope

This PR enables the "Continue" button for DAO Group proposals even when no actions are defined, allowing users to create proposals without associated actions.

## Work Done

1.  Removed the `disabled` condition from the "Continue" button in `SetupActions.tsx`.
2.  Updated the message displaying the number of actions to provide clearer text when zero actions are present, including proper pluralization for action counts.

## Steps to Test

1.  Navigate to create a new DAO Group proposal.
2.  Proceed to the "Setup Actions" step.
3.  Observe that the "Continue" button is enabled even if no actions are added.
4.  Verify the message above the form correctly states "No actions will be executed when the proposal passes." when no actions are present.
5.  Add one or more actions and verify the message updates correctly (e.g., "The following 1 action gets executed..." or "The following 2 actions get executed...").

## Screenshots

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-9513d366-dcc6-41c3-a6eb-6d9b166b92a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9513d366-dcc6-41c3-a6eb-6d9b166b92a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

